### PR TITLE
autotools: removed creation of "config.h" file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,6 @@ AC_CACHE_SAVE
 dnl page
 #### finish
 
-AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile]
    [meta/scripts/libsv.pc])
 AC_OUTPUT


### PR DESCRIPTION
I removed the creation of `config.h` file, so that all the preprocessor symbol definitions go on the command line of the compiler.  The alternative is to include `config.h` in all the source files as internal header; this is not needed right now.
